### PR TITLE
Create card on Trello when tc-i18n-hygiene check fails

### DIFF
--- a/README.md
+++ b/README.md
@@ -47,3 +47,11 @@ Loops over all lists on a board and prints the count of each card-type it holds:
 ### List the cards that have sat in Review column for more than two days
 
     lita lean review <trello board id>
+
+### List cards currently in the Confirmed column on the development board
+
+    lita lean confirmed-cards
+
+### Response to TCBOT when tc-i18n-hygiene check fails
+
+This will create a code directly on the Confirmed column on the development board

--- a/lib/lita-lean_tc.rb
+++ b/lib/lita-lean_tc.rb
@@ -24,6 +24,7 @@ module Lita
       config :trello_member_token
       config :development_board_id
       config :old_review_cards_channel
+      config :list_id
 
       on :loaded, :start_timer
       on :buildkite_build_finished, :build_finished
@@ -42,14 +43,14 @@ module Lita
 
       # Returns cards listed in Confirmed on the Development board
       def list_cards(response)
-        msg = NewCard.new(trello_client).display_confirmed_msg(config.development_board_id)
+        msg = NewCard.new(trello_client, config.list_id).display_confirmed_msg(config.development_board_id)
         response.reply("#{msg}")
       end
 
       # Creates a card with specified value in the Confirmed column on
       # the Development board when the tc-i18n-hygiene build fails
       def create_confirmed
-        new_card = NewCard.new(trello_client).create_new_card
+        new_card = NewCard.new(trello_client, config.list_id).create_new_card
         response = "#{new_card.name}, #{new_card.url}"
         robot.send_message(target, response)
       end

--- a/lib/lita-lean_tc.rb
+++ b/lib/lita-lean_tc.rb
@@ -2,6 +2,7 @@ require "lita"
 require 'trello'
 require 'lita-timing'
 require 'review_cards'
+require 'new_card'
 
 module Lita
   module Handlers
@@ -41,11 +42,8 @@ module Lita
 
       # Returns cards listed in Confirmed on the Development board
       def list_cards(response)
-        board_id = config.development_board_id
-        board = trello_client.find(:boards, board_id)
-        detect_confirmed(board).each do |card|
-          response.reply("#{card.name}, #{card.url}")
-        end
+        msg = NewCard.new(trello_client).display_confirmed_msg(config.development_board_id)
+        response.reply("#{msg}")
       end
 
       # Returns a count of cards on a Trello board, broken down by
@@ -245,11 +243,6 @@ module Lita
             !name.include?(COMMERCIAL)
         }.size
         result
-      end
-
-      def detect_confirmed(board)
-        list = board.lists.detect{|list| list.name.starts_with?('Confirmed')}
-        list.cards
       end
 
       def trello_client

--- a/lib/lita-lean_tc.rb
+++ b/lib/lita-lean_tc.rb
@@ -32,7 +32,8 @@ module Lita
       route(/\Alean breakdown ([a-zA-Z0-9]+)\Z/i, :breakdown, command: true, help: { "lean breakdown [board id]" => "Breakdown of card types on the nominated trello board"})
       route(/\Alean set-types ([a-zA-Z0-9]+)\Z/i, :set_types, command: true, help: { "lean set-types [board id]" => "Begin looping through cards without a type on the nominated trello board"})
       route(/\Alean set-streams ([a-zA-Z0-9]+)\Z/i, :set_streams, command: true, help: { "lean set-streams [board id]" => "Begin looping through cards without a stream on the nominated trello board"})
-      route(/\Alean confirmed-cards\Z/i, :list_cards, command: true, help: {"lean confirmed-cards" => "List all cards in the confirmed column"})
+      route(/\Alean confirmed-cards\Z/i, :list_cards, command: true, help: { "lean confirmed-cards" => "List all cards in the confirmed column" })
+      route(/\Alean create-new-confirmed\Z/i, :create_confirmed, commande: true, help: { "lean new-confirmed-card" => "Create a new card in the confirmed column" })
       route(/\A([bmtf])\Z/i, :type, command: false)
       route(/\A([cdo])\Z/i, :stream, command: false)
 
@@ -44,6 +45,12 @@ module Lita
       def list_cards(response)
         msg = NewCard.new(trello_client).display_confirmed_msg(config.development_board_id)
         response.reply("#{msg}")
+      end
+
+      # Creates a card with specified value in the Confirmed column on the Development board
+      def create_confirmed(response)
+        new_card = NewCard.new(trello_client).create_new_card("will this work")
+        response.reply("#{new_card.name}, #{new_card.url}")
       end
 
       # Returns a count of cards on a Trello board, broken down by

--- a/lib/lita-lean_tc.rb
+++ b/lib/lita-lean_tc.rb
@@ -33,7 +33,7 @@ module Lita
       route(/\Alean set-types ([a-zA-Z0-9]+)\Z/i, :set_types, command: true, help: { "lean set-types [board id]" => "Begin looping through cards without a type on the nominated trello board"})
       route(/\Alean set-streams ([a-zA-Z0-9]+)\Z/i, :set_streams, command: true, help: { "lean set-streams [board id]" => "Begin looping through cards without a stream on the nominated trello board"})
       route(/\Alean confirmed-cards\Z/i, :list_cards, command: true, help: { "lean confirmed-cards" => "List all cards in the confirmed column" })
-      route(/\Alean create-new-confirmed\Z/i, :create_confirmed, commande: true, help: { "lean new-confirmed-card" => "Create a new card in the confirmed column" })
+      route(/\AOh Oh, 0 day(s) since the last master failure on tc-i18n-hygiene\Z/i, :create_confirmed, command: true, help: { "Oh Oh, 0 day(s) since the last master failure on tc-i18n-hygiene" => "Create a new card in the confirmed column" })
       route(/\A([bmtf])\Z/i, :type, command: false)
       route(/\A([cdo])\Z/i, :stream, command: false)
 
@@ -49,7 +49,7 @@ module Lita
 
       # Creates a card with specified value in the Confirmed column on the Development board
       def create_confirmed(response)
-        new_card = NewCard.new(trello_client).create_new_card("will this work")
+        new_card = NewCard.new(trello_client).create_new_card
         response.reply("#{new_card.name}, #{new_card.url}")
       end
 

--- a/lib/lita-lean_tc.rb
+++ b/lib/lita-lean_tc.rb
@@ -21,7 +21,7 @@ module Lita
 
       config :trello_public_key
       config :trello_member_token
-      config :old_review_cards_board_id
+      config :development_board_id
       config :old_review_cards_channel
 
       on :loaded, :start_timer
@@ -121,7 +121,7 @@ module Lita
       def start_review_timer
         every_with_logged_errors(TIMER_INTERVAL) do |timer|
           daily_at("23:00", [:sunday, :monday, :tuesday, :wednesday, :thursday], "review-column-activity") do
-            msg = ReviewCards.new(trello_client).to_msg(config.old_review_cards_board_id)
+            msg = ReviewCards.new(trello_client).to_msg(config.development_board_id)
             robot.send_message(target, msg) if msg
           end
         end

--- a/lib/lita-lean_tc.rb
+++ b/lib/lita-lean_tc.rb
@@ -46,7 +46,8 @@ module Lita
         response.reply("#{msg}")
       end
 
-      # Creates a card with specified value in the Confirmed column on the Development board
+      # Creates a card with specified value in the Confirmed column on
+      # the Development board when the tc-i18n-hygiene build fails
       def create_confirmed
         new_card = NewCard.new(trello_client).create_new_card
         response = "#{new_card.name}, #{new_card.url}"
@@ -56,7 +57,7 @@ module Lita
       def build_finished(payload)
         event = payload[:event]
 
-        if event.pipeline_name == "tc-i18n-hygiene"
+        if event.pipeline_name == "tc-i18n-hygiene" && !event.passed?
           create_confirmed
         end
       end

--- a/lib/lita-lean_tc.rb
+++ b/lib/lita-lean_tc.rb
@@ -44,7 +44,7 @@ module Lita
         board_id = config.development_board_id
         board = trello_client.find(:boards, board_id)
         detect_confirmed(board).each do |card|
-          response.reply("#{card.name}")
+          response.reply("#{card.name}, #{card.url}")
         end
       end
 

--- a/lib/new_card.rb
+++ b/lib/new_card.rb
@@ -1,0 +1,26 @@
+module Lita
+  # Returns cards that are in the Confirmed column
+  class NewCard
+
+    def initialize(trello_client)
+      @trello_client = trello_client
+    end
+
+    def display_confirmed_msg(board_id)
+      board = @trello_client.find(:boards, board_id)
+      confirmed_cards = detect_confirmed(board)
+      message = "Confirmed cards:\n"
+      message += confirmed_cards.map do |card|
+        "#{card.name}, #{card.url}"
+      end.join("\n")
+    end
+
+    private
+
+    def detect_confirmed(board)
+      list = board.lists.detect{|list| list.name.starts_with?('Confirmed')}
+      list.cards
+    end
+
+  end
+end

--- a/lib/new_card.rb
+++ b/lib/new_card.rb
@@ -2,8 +2,9 @@ module Lita
   # Returns cards that are in the Confirmed column
   class NewCard
 
-    def initialize(trello_client)
+    def initialize(trello_client, list_id)
       @trello_client = trello_client
+      @list_id = list_id
     end
 
     def display_confirmed_msg(board_id)
@@ -17,7 +18,7 @@ module Lita
 
     def create_new_card
       data = {
-        'name'=>'tc-i18n-hygiene check failed', 'idList'=>'53423bf0e43c411a746ce27f', 'due'=>nil
+        'name'=>'tc-i18n-hygiene check failed', 'idList'=>"#{@list_id}", 'due'=>nil
       }
       @trello_client.create(:card, data)
     end

--- a/lib/new_card.rb
+++ b/lib/new_card.rb
@@ -8,7 +8,7 @@ module Lita
 
     def display_confirmed_msg(board_id)
       board = @trello_client.find(:boards, board_id)
-      confirmed_cards = detect_confirmed(board)
+      confirmed_cards = detect_confirmed(board).cards
       message = "Confirmed cards:\n"
       message += confirmed_cards.map do |card|
         "#{card.name}, #{card.url}"
@@ -19,7 +19,6 @@ module Lita
 
     def detect_confirmed(board)
       list = board.lists.detect{|list| list.name.starts_with?('Confirmed')}
-      list.cards
     end
 
   end

--- a/lib/new_card.rb
+++ b/lib/new_card.rb
@@ -15,6 +15,13 @@ module Lita
       end.join("\n")
     end
 
+    def create_new_card(name)
+      data = {
+        'name'=>'will this work?', 'idList'=>'53423bf0e43c411a746ce27f', 'due'=>nil
+      }
+      @trello_client.create(:card, data)
+    end
+
     private
 
     def detect_confirmed(board)

--- a/lib/new_card.rb
+++ b/lib/new_card.rb
@@ -15,9 +15,9 @@ module Lita
       end.join("\n")
     end
 
-    def create_new_card(name)
+    def create_new_card
       data = {
-        'name'=>'will this work?', 'idList'=>'53423bf0e43c411a746ce27f', 'due'=>nil
+        'name'=>'tc-i18n-hygiene check failed', 'idList'=>'53423bf0e43c411a746ce27f', 'due'=>nil
       }
       @trello_client.create(:card, data)
     end


### PR DESCRIPTION
This creates a card in the Confirmed column on the Development board on Trello when the `tc-i18n-hygiene` check fails.
It also adds a little route to list the cards in the confirmed column.
It's using the buildkite pipeline, @yob's buildkite handler: https://github.com/conversation/lita-buildkite and Ruby Trello https://github.com/jeremytregunna/ruby-trello to handle the Trello API.
I've got a seperate branch ready to go to implement the config changes to lita once this is merged
# To Test
- Checkout this branch: https://github.com/conversation/tc-lita/pull/89
- Change line `tc-lita/Gemfile:14` to take local path of lita-lean_tc instead of github
- Open lita-buildkite repo and edit line 34 in `spec/fixtures/buildkite_build_finished.json` to change the `pipeline name` to `tc-i18n-hygiene`.
- Open `lita-lean_tc` and remove the `!` from line 61 so the event passes 
- Run lita with `TRELLO_PUBLIC_KEY` and `TRELLO_MEMBER_TOKEN` defined
- Run this command in the buildkite repo `curl -v -X POST --data @spec/fixtures/buildkite_build_finished.json http://127.0.0.1:3010/buildkite`
- See your happily created trello card.
