### PR TITLE
List activity on feature request wall in Slack

### DIFF
--- a/lib/feature_requests.rb
+++ b/lib/feature_requests.rb
@@ -19,6 +19,15 @@ module Lita
       }.join("\n")
     end
 
+    # Returns a list of all cards on the Feature request board
+    #
+    def all_feature_request(board_id)
+      board = @trello_client.find(:boards, board_id)
+      board.cards.map{ |card|
+        "#{card.name}, #{card.short_url}, #{card.list.name}"
+      }.join("\n")
+    end
+
     private
 
     def seven_days_in_seconds

--- a/lib/feature_requests.rb
+++ b/lib/feature_requests.rb
@@ -1,5 +1,5 @@
 module Lita
-  # Returns cards that have been in Review column for more than two days
+# A class for dealing with the feature request board on trello
   class FeatureRequests
 
     SEVEN_DAYS = (60*60*24*7)
@@ -8,6 +8,8 @@ module Lita
       @trello_client = trello_client
     end
 
+    # Select cards created within the previous seven days
+    #
     def to_msg(board_id)
       board = @trello_client.find(:boards, board_id)
       board.cards.select{ |card|

--- a/lib/feature_requests.rb
+++ b/lib/feature_requests.rb
@@ -2,7 +2,7 @@ module Lita
   # Returns cards that have been in Review column for more than two days
   class FeatureRequests
 
-    SEVEN_DAYS = (60*60*168)
+    SEVEN_DAYS = (60*60*24*7)
 
     def initialize(trello_client)
       @trello_client = trello_client

--- a/lib/feature_requests.rb
+++ b/lib/feature_requests.rb
@@ -1,0 +1,27 @@
+module Lita
+  # Returns cards that have been in Review column for more than two days
+  class FeatureRequests
+
+    SEVEN_DAYS = (60*60*168)
+
+    def initialize(trello_client)
+      @trello_client = trello_client
+    end
+
+    def to_msg(board_id)
+      board = @trello_client.find(:boards, board_id)
+      board.cards.select{ |card|
+        card.actions.last.date > seven_days_in_seconds
+      }.map{ |card|
+        "#{card.name}, #{card.short_url}, #{card.list.name}"
+      }.join("\n")
+    end
+
+    private
+
+    def seven_days_in_seconds
+      ::Time.now - SEVEN_DAYS
+    end
+
+  end
+end

--- a/lib/feature_requests.rb
+++ b/lib/feature_requests.rb
@@ -21,7 +21,7 @@ module Lita
 
     # Returns a list of all cards on the Feature request board
     #
-    def all_feature_request(board_id)
+    def all_feature_requests(board_id)
       board = @trello_client.find(:boards, board_id)
       board.cards.map{ |card|
         "#{card.name}, #{card.short_url}, #{card.list.name}"

--- a/lib/lita-lean_tc.rb
+++ b/lib/lita-lean_tc.rb
@@ -66,14 +66,11 @@ module Lita
           create_confirmed
         end
       end
-      # Returns a list of all cards on the Feature request board
-      #
+
+      # Lists all cards on the feature request wall
       def list_feature_request(response)
-        board_id = config.feature_board_id
-        board = trello_client.find(:boards, board_id)
-        board.cards.each do |card|
-          response.reply("#{card.name}, #{card.url}", "#{card.list.name}")
-        end
+        msg = FeatureRequests.new(trello_client).all_feature_request(config.feature_board_id)
+        response.reply("#{msg}")
       end
 
       # Returns a count of cards on a Trello board, broken down by

--- a/lib/lita-lean_tc.rb
+++ b/lib/lita-lean_tc.rb
@@ -36,7 +36,7 @@ module Lita
       route(/\Alean set-types ([a-zA-Z0-9]+)\Z/i, :set_types, command: true, help: { "lean set-types [board id]" => "Begin looping through cards without a type on the nominated trello board"})
       route(/\Alean set-streams ([a-zA-Z0-9]+)\Z/i, :set_streams, command: true, help: { "lean set-streams [board id]" => "Begin looping through cards without a stream on the nominated trello board"})
       route(/\Alean confirmed-cards\Z/i, :list_cards, command: true, help: { "lean confirmed-cards" => "List all cards in the confirmed column" })
-      route(/\Alean list-feature-requests\Z/i, :list_feature_request, command: true, help: { "lean list-feature-requests" => "List all cards on the Feature Request board" })
+      route(/\Alean list-feature-requests\Z/i, :list_feature_requests, command: true, help: { "lean list-feature-requests" => "List all cards on the Feature Request board" })
       route(/\A([bmtf])\Z/i, :type, command: false)
       route(/\A([cdo])\Z/i, :stream, command: false)
 
@@ -66,10 +66,10 @@ module Lita
           create_confirmed
         end
       end
-
-      # Lists all cards on the feature request wall
-      def list_feature_request(response)
-        msg = FeatureRequests.new(trello_client).all_feature_request(config.feature_board_id)
+      #
+      # # Lists all cards on the feature request wall
+      def list_feature_requests(response)
+        msg = FeatureRequests.new(trello_client).all_feature_requests(config.feature_board_id)
         response.reply("#{msg}")
       end
 

--- a/lib/lita-lean_tc.rb
+++ b/lib/lita-lean_tc.rb
@@ -34,6 +34,7 @@ module Lita
       route(/\Alean set-types ([a-zA-Z0-9]+)\Z/i, :set_types, command: true, help: { "lean set-types [board id]" => "Begin looping through cards without a type on the nominated trello board"})
       route(/\Alean set-streams ([a-zA-Z0-9]+)\Z/i, :set_streams, command: true, help: { "lean set-streams [board id]" => "Begin looping through cards without a stream on the nominated trello board"})
       route(/\Alean confirmed-cards\Z/i, :list_cards, command: true, help: { "lean confirmed-cards" => "List all cards in the confirmed column" })
+      route(/\lean list-feature-requests\Z/i, :list_feature_request, command: true, help: { "lean feature-request" => "List all cards on the Feature Request baord" })
       route(/\A([bmtf])\Z/i, :type, command: false)
       route(/\A([cdo])\Z/i, :stream, command: false)
 
@@ -60,6 +61,14 @@ module Lita
 
         if event.pipeline_name == "tc-i18n-hygiene" && !event.passed?
           create_confirmed
+      end
+      # Returns a list of all cards on the Feature request board
+      #
+      def list_feature_request(response)
+        board_id = "hD3oNZ2P"
+        board = trello_client.find(:boards, board_id)
+        board.cards.each do |card|
+          response.reply("#{card.name}, #{card.url}", "#{card.list.name}")
         end
       end
 

--- a/lib/lita-lean_tc.rb
+++ b/lib/lita-lean_tc.rb
@@ -36,7 +36,7 @@ module Lita
       route(/\Alean set-types ([a-zA-Z0-9]+)\Z/i, :set_types, command: true, help: { "lean set-types [board id]" => "Begin looping through cards without a type on the nominated trello board"})
       route(/\Alean set-streams ([a-zA-Z0-9]+)\Z/i, :set_streams, command: true, help: { "lean set-streams [board id]" => "Begin looping through cards without a stream on the nominated trello board"})
       route(/\Alean confirmed-cards\Z/i, :list_cards, command: true, help: { "lean confirmed-cards" => "List all cards in the confirmed column" })
-      route(/\Alean list-feature-requests\Z/i, :list_feature_request, command: true, help: { "lean feature-request" => "List all cards on the Feature Request baord" })
+      route(/\Alean list-feature-requests\Z/i, :list_feature_request, command: true, help: { "lean feature-request" => "List all cards on the Feature Request board" })
       route(/\A([bmtf])\Z/i, :type, command: false)
       route(/\A([cdo])\Z/i, :stream, command: false)
 

--- a/lib/lita-lean_tc.rb
+++ b/lib/lita-lean_tc.rb
@@ -23,6 +23,7 @@ module Lita
       config :trello_public_key
       config :trello_member_token
       config :development_board_id
+      config :feature_board_id
       config :old_review_cards_channel
       config :list_id
 
@@ -34,7 +35,7 @@ module Lita
       route(/\Alean set-types ([a-zA-Z0-9]+)\Z/i, :set_types, command: true, help: { "lean set-types [board id]" => "Begin looping through cards without a type on the nominated trello board"})
       route(/\Alean set-streams ([a-zA-Z0-9]+)\Z/i, :set_streams, command: true, help: { "lean set-streams [board id]" => "Begin looping through cards without a stream on the nominated trello board"})
       route(/\Alean confirmed-cards\Z/i, :list_cards, command: true, help: { "lean confirmed-cards" => "List all cards in the confirmed column" })
-      route(/\lean list-feature-requests\Z/i, :list_feature_request, command: true, help: { "lean feature-request" => "List all cards on the Feature Request baord" })
+      route(/\Alean list-feature-requests\Z/i, :list_feature_request, command: true, help: { "lean feature-request" => "List all cards on the Feature Request baord" })
       route(/\A([bmtf])\Z/i, :type, command: false)
       route(/\A([cdo])\Z/i, :stream, command: false)
 
@@ -61,11 +62,12 @@ module Lita
 
         if event.pipeline_name == "tc-i18n-hygiene" && !event.passed?
           create_confirmed
+        end
       end
       # Returns a list of all cards on the Feature request board
       #
       def list_feature_request(response)
-        board_id = "hD3oNZ2P"
+        board_id = config.feature_board_id
         board = trello_client.find(:boards, board_id)
         board.cards.each do |card|
           response.reply("#{card.name}, #{card.url}", "#{card.list.name}")

--- a/lib/lita-lean_tc.rb
+++ b/lib/lita-lean_tc.rb
@@ -36,7 +36,7 @@ module Lita
       route(/\Alean set-types ([a-zA-Z0-9]+)\Z/i, :set_types, command: true, help: { "lean set-types [board id]" => "Begin looping through cards without a type on the nominated trello board"})
       route(/\Alean set-streams ([a-zA-Z0-9]+)\Z/i, :set_streams, command: true, help: { "lean set-streams [board id]" => "Begin looping through cards without a stream on the nominated trello board"})
       route(/\Alean confirmed-cards\Z/i, :list_cards, command: true, help: { "lean confirmed-cards" => "List all cards in the confirmed column" })
-      route(/\Alean list-feature-requests\Z/i, :list_feature_request, command: true, help: { "lean feature-request" => "List all cards on the Feature Request board" })
+      route(/\Alean list-feature-requests\Z/i, :list_feature_request, command: true, help: { "lean list-feature-requests" => "List all cards on the Feature Request board" })
       route(/\A([bmtf])\Z/i, :type, command: false)
       route(/\A([cdo])\Z/i, :stream, command: false)
 

--- a/lib/lita-lean_tc.rb
+++ b/lib/lita-lean_tc.rb
@@ -168,7 +168,7 @@ module Lita
 
       def start_feature_timer
         every_with_logged_errors(TIMER_INTERVAL) do |timer|
-          daily_at("00:00", [:monday], "feature-request-activity") do
+          daily_at("23:00", [:sunday], "feature-request-activity") do
             msg = FeatureRequests.new(trello_client).to_msg(config.feature_board_id)
             robot.send_message(target, msg) if msg
           end

--- a/lib/lita-lean_tc.rb
+++ b/lib/lita-lean_tc.rb
@@ -175,14 +175,6 @@ module Lita
         end
       end
 
-      def days_in_seconds(days)
-        60 * 60* 24 * days.to_i
-      end
-
-      def seven_days_in_seconds
-        ::Time.now - SEVEN_DAYS
-      end
-
       def every_with_logged_errors(interval, &block)
         logged_errors do
           every(interval, &block)

--- a/lib/lita-lean_tc.rb
+++ b/lib/lita-lean_tc.rb
@@ -168,7 +168,7 @@ module Lita
 
       def start_feature_timer
         every_with_logged_errors(TIMER_INTERVAL) do |timer|
-          daily_at("23:00", [:monday], "feature-request-activity") do
+          daily_at("00:00", [:monday], "feature-request-activity") do
             msg = FeatureRequests.new(trello_client).to_msg(config.feature_board_id)
             robot.send_message(target, msg) if msg
           end


### PR DESCRIPTION
This starts a timer that will post a message in slack each Monday morning at 10am of the cards that have been created on the feature request board in the last seven days.

The timer uses `lita-timing` to handle the `daily_at` method. To get the events into lita as soon as lita's started, the `start_feature_timer` method will need to look like this:

``````
  ```def start_feature_timer
    #every_with_logged_errors(TIMER_INTERVAL) do |timer|
      #daily_at("23:00", [:sunday], "feature-request-activity") do
        msg = FeatureRequests.new(trello_client).to_msg("hD3oNZ2P")
        robot.send_message(target, msg) if msg
      #end
    #end
  end```
``````
