### PR TITLE
Improve failed build card with label and URL

### DIFF
--- a/lib/lita-lean_tc.rb
+++ b/lib/lita-lean_tc.rb
@@ -27,6 +27,7 @@ module Lita
       config :feature_board_id
       config :old_review_cards_channel
       config :list_id
+      config :id_labels
 
       on :loaded, :start_timer
       on :buildkite_build_finished, :build_finished
@@ -54,7 +55,7 @@ module Lita
       # Creates a card with specified value in the Confirmed column on
       # the Development board when the tc-i18n-hygiene build fails
       def create_confirmed
-        new_card = NewCard.new(trello_client, config.list_id).create_new_card
+        new_card = NewCard.new(trello_client, config.list_id, config.id_labels).create_new_card
         response = "#{new_card.name}, #{new_card.url}"
         robot.send_message(target, response)
       end

--- a/lib/new_card.rb
+++ b/lib/new_card.rb
@@ -1,10 +1,12 @@
+require 'pry'
 module Lita
   # Returns cards that are in the Confirmed column
   class NewCard
 
-    def initialize(trello_client, list_id)
+    def initialize(trello_client, list_id, id_labels)
       @trello_client = trello_client
       @list_id = list_id
+      @id_labels = id_labels
     end
 
     def display_confirmed_msg(board_id)
@@ -18,7 +20,11 @@ module Lita
 
     def create_new_card
       data = {
-        'name'=>'tc-i18n-hygiene check failed', 'idList'=>"#{@list_id}", 'due'=>nil
+        'name'=>'tc-i18n-hygiene check failed',
+        'idList'=>"#{@list_id}",
+        'due'=>nil,
+        'labels'=>['name'=>'TC','color'=>'green'],
+        'idLabels'=>["#{@id_labels}"]
       }
       @trello_client.create(:card, data)
     end

--- a/lib/new_card.rb
+++ b/lib/new_card.rb
@@ -23,7 +23,6 @@ module Lita
         'idList'=>"#{@list_id}",
         'due'=>nil,
         'desc'=>'https://buildkite.com/conversation/tc-i18n-hygiene',
-        'labels'=>['name'=>'TC','color'=>'green'],
         'idLabels'=>["#{@id_labels}"]
       }
       @trello_client.create(:card, data)

--- a/lib/new_card.rb
+++ b/lib/new_card.rb
@@ -1,4 +1,3 @@
-require 'pry'
 module Lita
   # Returns cards that are in the Confirmed column
   class NewCard

--- a/lib/new_card.rb
+++ b/lib/new_card.rb
@@ -23,6 +23,7 @@ module Lita
         'name'=>'tc-i18n-hygiene check failed',
         'idList'=>"#{@list_id}",
         'due'=>nil,
+        'desc'=>'https://buildkite.com/conversation/tc-i18n-hygiene',
         'labels'=>['name'=>'TC','color'=>'green'],
         'idLabels'=>["#{@id_labels}"]
       }


### PR DESCRIPTION
This relies on https://github.com/conversation/tc-lita/pull/97 for the `id_label`.
I have had a hard time figuring out how to get the URL of the exact failed build to pipe into the description of the card, as the `data` doesn't seem to have access to the `event` in `lib/lita-lean_tc.rb`. So for now it's just a link to the buildkite master branch fro `tc-i18n-hygiene`. Opinions and advice more than welcome!
