### PR TITLE
Include accurate build-web_url from event

### DIFF
--- a/lib/lita-lean_tc.rb
+++ b/lib/lita-lean_tc.rb
@@ -54,18 +54,17 @@ module Lita
 
       # Creates a card with specified value in the Confirmed column on
       # the Development board when the tc-i18n-hygiene build fails
-      def create_confirmed
-        new_card = NewCard.new(trello_client, config.list_id, config.id_labels, @build_url).create_new_card
+      def create_confirmed(build_url)
+        new_card = NewCard.new(trello_client, config.list_id, config.id_labels, build_url).create_new_card
         response = "#{new_card.name}, #{new_card.url}"
         robot.send_message(target, response)
       end
 
       def build_finished(payload)
         event = payload[:event]
-        @build_url = event.build_web_url
 
         if event.pipeline_name == "tc-i18n-hygiene" && !event.passed?
-          create_confirmed
+          create_confirmed(event.build_web_url)
         end
       end
       #

--- a/lib/lita-lean_tc.rb
+++ b/lib/lita-lean_tc.rb
@@ -55,13 +55,14 @@ module Lita
       # Creates a card with specified value in the Confirmed column on
       # the Development board when the tc-i18n-hygiene build fails
       def create_confirmed
-        new_card = NewCard.new(trello_client, config.list_id, config.id_labels).create_new_card
+        new_card = NewCard.new(trello_client, config.list_id, config.id_labels, @build_url).create_new_card
         response = "#{new_card.name}, #{new_card.url}"
         robot.send_message(target, response)
       end
 
       def build_finished(payload)
         event = payload[:event]
+        @build_url = event.build_web_url
 
         if event.pipeline_name == "tc-i18n-hygiene" && !event.passed?
           create_confirmed

--- a/lib/new_card.rb
+++ b/lib/new_card.rb
@@ -2,10 +2,11 @@ module Lita
   # Returns cards that are in the Confirmed column
   class NewCard
 
-    def initialize(trello_client, list_id, id_labels)
+    def initialize(trello_client, list_id, id_labels, build_url)
       @trello_client = trello_client
       @list_id = list_id
       @id_labels = id_labels
+      @build_url = build_url
     end
 
     def display_confirmed_msg(board_id)
@@ -22,7 +23,7 @@ module Lita
         'name'=>'tc-i18n-hygiene check failed',
         'idList'=>"#{@list_id}",
         'due'=>nil,
-        'desc'=>'https://buildkite.com/conversation/tc-i18n-hygiene',
+        'desc'=>"#{@build_url}",
         'idLabels'=>["#{@id_labels}"]
       }
       @trello_client.create(:card, data)


### PR DESCRIPTION
This PR relied upon the change implemented in this PR: https://github.com/conversation/lita-buildkite/pull/1, which gives access to the `web_url` of the build, allowing me to include it in the description on the trello card.
I'm not sure that I've implemented this the best way, but it was the first way that came to mind and to my absolute surprise, it worked. Suggestions and opinions welcome.
It wouldn't include the url in the description if the `@build_url` instance was absent from the initialiser. 
