### PR TITLE
Include a puts to inspect data elements

### DIFF
--- a/lib/new_card.rb
+++ b/lib/new_card.rb
@@ -26,6 +26,7 @@ module Lita
         'desc'=>"#{@build_url}",
         'idLabels'=>["#{@id_labels}"]
       }
+      puts data.inspect
       @trello_client.create(:card, data)
     end
 


### PR DESCRIPTION
The label isn't being included in the trello card that's created when the hygiene check fails for tc-i18n-hygiene, despite working fine locally and including the expected data in the JSON exporter for that card. Outputs the expected values in console too.
